### PR TITLE
Fix output from tidytab::tab()

### DIFF
--- a/css/font.css
+++ b/css/font.css
@@ -2,7 +2,7 @@
 @import url('https://fonts.googleapis.com/css2?family=Inconsolata&display=swap');
 
 .remark-code, .remark-inline-code {
-  font-family: 'Inconsolata', 'Quattrocento', monospace;
+  font-family: 'Monaco', monospace;
 }
 
 h1 {

--- a/slides.Rmd
+++ b/slides.Rmd
@@ -135,11 +135,21 @@ class: center
 
 .panel[.panel-name[Console Table]
 
-```{r}
-# install.packages("devtools")
-# devtools::install_github("gvelasq/tidytab")
+```{r, eval = FALSE}
+# install.packages("remotes")
+# remotes::install_github("gvelasq/tidytab")
+library(tidytab)
 
-tidytab::tab(mtcars, cyl)
+mtcars %>% tab(cyl)
+```
+```
+##         cyl │      Freq.     Percent        Cum. 
+## ────────────┼───────────────────────────────────
+##           4 │         11        34.4        34.4 
+##           6 │          7        21.9        56.3 
+##           8 │         14        43.8       100.0 
+## ────────────┼───────────────────────────────────
+##       Total │         32       100.0           
 ```
 
 .palegrey[.right[.footnote[Source: tidytab, @gvelasq]]]

--- a/slides.html
+++ b/slides.html
@@ -121,12 +121,12 @@ class: center
 
 
 ```r
-# install.packages("devtools")
-# devtools::install_github("gvelasq/tidytab")
+# install.packages("remotes")
+# remotes::install_github("gvelasq/tidytab")
+library(tidytab)
 
-tidytab::tab(mtcars, cyl)
+mtcars %&gt;% tab(cyl)
 ```
-
 ```
 ##         cyl │      Freq.     Percent        Cum. 
 ## ────────────┼───────────────────────────────────
@@ -134,7 +134,7 @@ tidytab::tab(mtcars, cyl)
 ##           6 │          7        21.9        56.3 
 ##           8 │         14        43.8       100.0 
 ## ────────────┼───────────────────────────────────
-##       Total │         32       100.0           
+##       Total │         32       100.0           
 ```
 
 .palegrey[.right[.footnote[Source: tidytab, @gvelasq]]]


### PR DESCRIPTION
There were two issues:

1. The fonts in this section were not aligning the horizontal block drawing characters correctly. I fixed it by switching to Monaco which is the default RStudio monospace font on macOS:

```css
.remark-code, .remark-inline-code {
  font-family: 'Monaco', monospace;
}
```

2. I couldn't stop xaringan and/or remark.js from displaying the `&nbsp;`, which is placed there on purpose by [`tidytab::tab()`](https://github.com/gvelasq/tidytab/blob/b3a20e72c4b905633b20195cce4d00b0e00ee0fa/R/tab.R#L146) as a placeholder. To get around this I set `eval = FALSE` and copy/pasted the output in its own code chunk.

I also made a small change: tidytab exports `%>%`, so I switched the code to `mtcars %>% tab(cyl)` after `library(tidytab)`.